### PR TITLE
add two args in DIRECTION enum to eliminate the need for case & switch statements

### DIFF
--- a/SpyGame/src/edu/cpp/cs/cs141/final_proj/GameEngine.java
+++ b/SpyGame/src/edu/cpp/cs/cs141/final_proj/GameEngine.java
@@ -212,19 +212,7 @@ public class GameEngine {
 	 * @param lookDirection The direction to look in.
 	 */
 	public String playerLook(DIRECTION lookDirection) {
-		switch (lookDirection)
-		{
-		case UP:
-			return playerLook(0, -1, Spy.LOOK_RANGE);
-		case RIGHT:
-			return playerLook(1, 0, Spy.LOOK_RANGE);
-		case DOWN:
-			return playerLook(0, 1, Spy.LOOK_RANGE);
-		case LEFT:
-			return playerLook(-1, 0, Spy.LOOK_RANGE);
-		default:
-			return new String("What kind of direction was that?");	
-		}
+		return playerLook(lookDirection.deltaX, lookDirection.deltaY, Spy.LOOK_RANGE);
 	}
 	
 	/**

--- a/SpyGame/src/edu/cpp/cs/cs141/final_proj/Grid.java
+++ b/SpyGame/src/edu/cpp/cs/cs141/final_proj/Grid.java
@@ -19,11 +19,16 @@ public class Grid implements Serializable {
 	 * Stores the different directions that can be easily interpreted by the {@link #gameObjects}.
 	 */
 	public enum DIRECTION {
-		UP("w"), RIGHT("d"), DOWN("s"), LEFT("a");
+		UP("w", 0, -1), RIGHT("d", 1, 0), DOWN("s", 0, 1), LEFT("a", -1, 0);
 		
 		public final String keyCode;
-		private DIRECTION(String code) {
+		public final int deltaX;
+		public final int deltaY;
+		
+		private DIRECTION(String code, int dX, int dY) {
 			keyCode = code;
+			deltaX = dX;
+			deltaY = dY;
 		}
 		
 		/**
@@ -151,25 +156,8 @@ public class Grid implements Serializable {
 	 * @return array of integers representing the coordinate after moving in the (parameter) direction
 	 */
 	private int[] getCoordinate(DIRECTION direction, int x, int y) {
-		int moveX = x;
-		int moveY = y;
-		switch (direction)
-		{
-		case UP:
-			moveY--;
-			break;
-		case RIGHT:
-			moveX++;
-			break;
-		case DOWN:
-			moveY++;
-			break;
-		case LEFT:
-			moveX--;
-			break;
-		default:
-			System.err.println("Invalid direction given");
-		}
+		int moveX = x + direction.deltaX;
+		int moveY = y + direction.deltaY;
 		int[] coord = {moveX, moveY};
 		return coord;
 	}

--- a/SpyGame/src/edu/cpp/cs/cs141/final_proj/Weapon.java
+++ b/SpyGame/src/edu/cpp/cs/cs141/final_proj/Weapon.java
@@ -45,20 +45,7 @@ public abstract class Weapon implements Serializable {
 	 * @return
 	 */
 	public boolean attack(DIRECTION shootDirection, Character character, Grid grid) {
-		switch (shootDirection)
-		{
-		case UP:
-			return attack(0, -1, character, grid);
-		case RIGHT:
-			return attack(1, 0, character, grid);
-		case DOWN:
-			return attack(0, 1, character, grid);
-		case LEFT:
-			return attack(-1, 0, character, grid);
-		default:
-			System.err.println("Invalid shoot option");
-			return false;
-		}
+		return attack(shootDirection.deltaX, shootDirection.deltaY, character, grid);
 	}
 	
 	/**


### PR DESCRIPTION
This is a only a smaller refactor across several classes, but I think was worth sharing and pointing out so I'll make this a pull request.

What I've done is added two `public static final` attributes in the `enum DIRECTION`, `deltaX` and `deltaY`.

This now allows us to access the change in x and y from the value of the `DIRECTION` enum value without having to do a switch and case or multiple conditional statements throughout the code.

I tested it out a bit, it seems to work as expected for me.